### PR TITLE
Get a list from wp-config.php or set a default of our own site + word…

### DIFF
--- a/admin/class-inspect-http-requests-admin.php
+++ b/admin/class-inspect-http-requests-admin.php
@@ -213,9 +213,27 @@ class Inspect_Http_Requests_Admin {
 	 * @since    1.0.0
 	 */
 	public function ets_inspect_http_requests_ignore_specific_hostname( $data ) {
-		if ( false !== strpos( $data['URL'], 'wordpress.org' ) ) {
-			return false;
+
+		/* Try to get $ignored_urls from wp.config.php */
+		$ignored_urls = get_option('inspect-http-requests-ignored-urls');
+
+		/* Not found? Create a default */
+		if ( !is_array( $ignored_urls ) ) {
+			/* Get the BASE-URL of the wordpress site and remove the scheme  */
+			$site_url = home_url();
+			$url_parts = parse_url($site_url);
+	       		$url_base  = $url_parts['host'];
+			/* Create $ignored_urls */
+			$ignored_urls = [ $url_base, 'wordpress.org'];
 		}
+
+		/* Loop through the ignorelist */
+		foreach ($ignored_urls as $iu) {
+                	if ( false !== strpos( $data['URL'], $iu ) ) {
+                        	return false;
+                	}
+		}
+
 		if ( ets_inspect_http_request_check_duplicate_url( $data['URL'] ) ) {
 			return false;
 		}


### PR DESCRIPTION
…press.org

Enable by setting:
define( 'inspect-http-requests-ignored-urls', ['yoursite.com','api.wordpress.org','api'] );